### PR TITLE
Hash files stored in default attachment location

### DIFF
--- a/docs/tactics/initial_access.md
+++ b/docs/tactics/initial_access.md
@@ -13,7 +13,8 @@ Initial Access
 ```sql tab="Windows"
 SELECT * FROM hash 
 WHERE (path LIKE 'C:\Users\%\AppData\Local\Temp\%.tmp\%' 
-OR path LIKE 'C:\Users\%\AppData\Local\Microsoft\Outlook%%');
+OR path LIKE 'C:\Users\%\AppData\Local\Microsoft\Outlook%%'
+OR path LIKE 'C:\Documents and Settings\%\Local Settings\Temporary Internet Files\Content.Outlook%%');
 ```
 
 ## File Opening


### PR DESCRIPTION
I added the `C:\Documents and Settings\%\Local Settings\Temporary Internet Files\Content.Outlook%%` location as well per this [Microsoft Support article](https://support.microsoft.com/en-us/help/817878/attachments-remain-in-the-outlook-secure-temporary-file-folder-when-yo).

While files in this location do not necessarily imply the files were opened/executed, It can confirm delivery of an email attachment payload through a users Outlook client.